### PR TITLE
Remove default url

### DIFF
--- a/cape/client/client.py
+++ b/cape/client/client.py
@@ -35,7 +35,7 @@ class CapeClient:
         The CapeClient provides access to all methods of the Cape API.
     """
 
-    def __init__(self, api_base='https://responder.thecape.ai/api', admin_token=None):
+    def __init__(self, api_base, admin_token=None):
         """
 
         :param api_base: The URL to send API requests to.


### PR DESCRIPTION
Linked to issue https://github.com/bloomsburyai/cape-client/issues/1

Removing the default URL/Endpoint which is no longer live, making it more obvious to the user that they must provide an endpoint for the backend.